### PR TITLE
Hddtemp fix issue 4

### DIFF
--- a/sensor-exporter/main.go
+++ b/sensor-exporter/main.go
@@ -161,16 +161,15 @@ func (h *HddCollector) Init() error {
 }
 
 func (h *HddCollector) readTempsFromConn() (string, error) {
-	if h.conn == nil {
-		if err := h.Init(); err != nil {
-			return "", err
-		}
+	if err := h.Init(); err != nil {
+		return "", err
 	}
-
+        h.buf.Reset()
 	_, err := io.Copy(&h.buf, h.conn)
 	if err != nil {
 		return "", fmt.Errorf("Error reading from hddtemp socket: %v", err)
 	}
+	h.conn.Close()
 	return h.buf.String(), nil
 }
 

--- a/sensor-exporter/main.go
+++ b/sensor-exporter/main.go
@@ -1,6 +1,5 @@
 package main
 
-
 import (
 	"bytes"
 	"flag"

--- a/sensor-exporter/main.go
+++ b/sensor-exporter/main.go
@@ -1,5 +1,6 @@
 package main
 
+
 import (
 	"bytes"
 	"flag"


### PR DESCRIPTION
By closing and opening new connection to hddtemp daemon, we fetch new data with every call. Also the reset of buffer is needed to have where to write new data.

Should fix issue https://github.com/ncabatoff/sensor-exporter/issues/4